### PR TITLE
Fix bug with start script

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xometry-react-scripts",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "Xometry configuration and scripts for Create React App.",
   "repository": {
     "type": "git",

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -52,9 +52,7 @@ const useYarn = fs.existsSync(paths.yarnLockFile);
 const isInteractive = process.stdout.isTTY;
 
 // Warn and crash if required files are missing
-if (
-  !checkRequiredFiles([paths.appHtml, paths.appIndexJs, paths.appComponentJs])
-) {
+if (!checkRequiredFiles([paths.appHtml, paths.appIndexJs])) {
   process.exit(1);
 }
 


### PR DESCRIPTION
Requiring `Component.tsx` to be there for the `yarn start` script doesn't make sense for the `cra-template`.
